### PR TITLE
Localize Word Processors tab in Preferences

### DIFF
--- a/resource/installer_common.jsm
+++ b/resource/installer_common.jsm
@@ -160,7 +160,7 @@ ZoteroPluginInstaller.prototype = {
 			Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
 				.getService(Components.interfaces.nsIPromptService)
 				.alert(null, this._addon.EXTENSION_STRING,
-				'Installation was successful.');
+				Zotero.getString("zotero.preferences.wordProcessors.installationSuccess"));
 		}
 	},
 	
@@ -177,7 +177,7 @@ ZoteroPluginInstaller.prototype = {
 		Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
 			.getService(Components.interfaces.nsIPromptService)
 			.alert(null, this._addon.EXTENSION_STRING,
-			(error ? error : 'Installation could not be completed because an error occurred. Please ensure that '+this._addon.APP+' is closed, and then restart '+Zotero.appName+'.'));
+			(error ? error : Zotero.getString("zotero.preferences.wordProcessors.installationError",[this._addon.APP, Zotero.appName])));
 	},
 	
 	"cancelled":function(dontSkipInstallation) {
@@ -198,14 +198,19 @@ ZoteroPluginInstaller.prototype = {
 		var description = document.createElement("description");
 		description.style.width = "45em";
 		description.appendChild(document.createTextNode(
-			"The "+this._addon.APP+" add-in is "+(isInstalled ? "" : "not ")+"currently installed."));
+			isInstalled ?
+				Zotero.getString('zotero.preferences.wordProcessors.installed', this._addon.APP) :
+				Zotero.getString('zotero.preferences.wordProcessors.notInstalled', this._addon.APP)));
 		groupbox.appendChild(description);
 
 		var hbox = document.createElement("hbox");
 		hbox.setAttribute("pack", "center");
 		var button = document.createElement("button"),
 			addon = this._addon;
-		button.setAttribute("label", (isInstalled ? "Reinstall" : "Install")+" "+this._addon.APP+" Add-in");
+		button.setAttribute("label", 
+			(isInstalled ?
+				Zotero.getString('zotero.preferences.wordProcessors.reinstall', this._addon.APP) :
+				Zotero.getString('zotero.preferences.wordProcessors.install', this._addon.APP)));
 		button.addEventListener("command", function() {
 			var zpi = new ZoteroPluginInstaller(addon, false, true);
 			zpi.showPreferences(document);
@@ -224,7 +229,7 @@ ZoteroPluginInstaller.prototype = {
 	
 	"_firstRunListener":function() {
 		this._progressWindowLabel = this._progressWindow.document.getElementById("progress-label");
-		this._progressWindowLabel.value = "Installing "+this._addon.EXTENSION_STRING+"...";
+		this._progressWindowLabel.value = Zotero.getString('zotero.preferences.wordProcessors.installing', this._addon.EXTENSION_STRING);
 		var me = this;
 		setTimeout(function() {
 			me._progressWindow.focus();
@@ -255,11 +260,11 @@ ZoteroPluginInstaller.prototype = {
 			
 			if((comp === null && checkAddon.required) || comp < 0) {
 				if(checkAddon.required === false) {
-					var err = this._addon.EXTENSION_STRING+' '+this._addons[0].version+' is incompatible with versions of '+checkAddon.name+
-						' before '+checkAddon.minVersion+'. Please remove '+checkAddon.name+', or download the latest version from '+checkAddon.url+'.';
+					var err = Zotero.getString("zotero.preferences.wordProcessors.incompatibleVersions1",
+						[this._addon.EXTENSION_STRING, this._addons[0].version, checkAddon.name, checkAddon.minVersion, checkAddon.url]);
 				} else {
-					var err = this._addon.EXTENSION_STRING+' '+this._addons[0].version+' requires '+checkAddon.name+' '+checkAddon.minVersion+
-						' or later to run. Please download the latest version of '+checkAddon.name+' from '+checkAddon.url+'.';
+					var err = Zotero.getString("zotero.preferences.wordProcessors.incompatibleVersions2",
+						[this._addon.EXTENSION_STRING, this._addons[0].version, checkAddon.name, checkAddon.minVersion, checkAddon.url]);
 				}
 				this.error(err, true);
 				if(this.failSilently) {


### PR DESCRIPTION
Fixes https://github.com/zotero/zotero/issues/426 : this localizes the Word Processors Add-in button and messages displayed in the Prefs, under the "Word Processors" tab.
Comes with https://github.com/zotero/zotero/pull/674