### PR TITLE
Clarify non-communication message.

### DIFF
--- a/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
+++ b/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
@@ -128,7 +128,7 @@ Sub ZoteroCommand(cmd As String, bringToFront As Boolean)
         End If
     Next
     If ThWnd = 0 Then
-        MsgBox ("Word could not communicate with Zotero. Please ensure Firefox is running and try again. If this problem persists, visit http://www.zotero.org/support/word_processor_plugin_troubleshooting")
+        MsgBox ("Word could not communicate with Zotero. Please ensure Firefox or Zotero Standalone is running and try again. If this problem persists, visit http://www.zotero.org/support/word_processor_plugin_troubleshooting")
         Exit Sub
     End If
     
@@ -167,4 +167,3 @@ Sub ZoteroCommand(cmd As String, bringToFront As Boolean)
         End If
     End If
 End Sub
-

--- a/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
+++ b/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
@@ -128,7 +128,7 @@ Sub ZoteroCommand(cmd As String, bringToFront As Boolean)
         End If
     Next
     If ThWnd = 0 Then
-        MsgBox ("Word could not communicate with Zotero. Please ensure Firefox or Zotero Standalone is running and try again. If this problem persists, visit http://www.zotero.org/support/word_processor_plugin_troubleshooting")
+        MsgBox ("Word could not communicate with Zotero. Please ensure Zotero is running and try again. If this problem persists, visit http://www.zotero.org/support/word_processor_plugin_troubleshooting")
         Exit Sub
     End If
     

--- a/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
+++ b/build/template/Zotero.dotm/word/vbaProject.bin/Zotero.bas
@@ -128,7 +128,7 @@ Sub ZoteroCommand(cmd As String, bringToFront As Boolean)
         End If
     Next
     If ThWnd = 0 Then
-        MsgBox ("Word could not communicate with Zotero. Please ensure Zotero is running and try again. If this problem persists, visit http://www.zotero.org/support/word_processor_plugin_troubleshooting")
+        MsgBox ("Word could not communicate with Zotero. Please ensure Zotero is running and try again. If this problem persists, visit https://www.zotero.org/support/word_processor_plugin_troubleshooting")
         Exit Sub
     End If
     


### PR DESCRIPTION
The message that is shown if the add-in cannot communicate with Zotero is a bit confusing for users of the standalone version of Zotero. This PR fixes that.