### PR TITLE
adjust the judgment logic of calling UndoRecord interfacex 

### DIFF
--- a/build/zoteroWinWordIntegration/zoteroWinWordIntegration.h
+++ b/build/zoteroWinWordIntegration/zoteroWinWordIntegration.h
@@ -147,6 +147,7 @@ typedef struct Document {
 	long restoreRevisionsMarkup;
 	bool statusScreenUpdating;
 	bool restoreTrackChanges;
+	bool hasUndoRecordInterface;
 	short insertTextIntoNote;
 	
 	listNode_t* allocatedFieldsStart;


### PR DESCRIPTION
In the past, whether to call the UndoRecord interface based on the word version. Now adjust to: checking whether the UndoRecord interface exists first, then decide to whether call the UndoRecord interface, this seems more safe and easier to understand.